### PR TITLE
Fix flags to start api with specific configpath and fix air setup

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -3,8 +3,8 @@ testdata_dir = "testdata"
 tmp_dir = "tmp"
 
 [build]
-  args_bin = []
-  bin = "./tmp/main --config_path=/cmd/api/config.yml"
+  args_bin = ["--config_path=$(pwd)/cmd/api"]
+  bin = "./tmp/main"
   cmd = "go build -o ./tmp/main ./cmd/api/main.go"
   delay = 1000
   exclude_dir = ["assets", "tmp", "vendor", "testdata"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ go mod tidy
 ```
 
 ## Usage
+Go into the project folder
+
+### First create a config yaml
+Execute the following command and change all sample values in your config to your needs.
+
+```sh
+cd cmd/api && cp config.sample.yml config.yml
+```
 
 ### Native way
 ```sh
@@ -23,6 +31,9 @@ cd cmd/api && go run main.go
 ```
 
 ### To use air
+First you have to install air. Instructions [here](https://github.com/cosmtrek/air).
+After air is installed, execute the command in root project folder.
+
 ```sh
 air
 ```

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/drzombey/aur-package-builder-api/pkg/tracing"
-	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
+
 	"github.com/drzombey/aur-package-builder-api/cmd/api/config"
 	"github.com/drzombey/aur-package-builder-api/cmd/api/handler"
+	"github.com/drzombey/aur-package-builder-api/pkg/tracing"
 	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/viper"
@@ -20,6 +21,7 @@ var (
 
 func init() {
 	flag.StringVar(&configPath, "config_path", ".", "path to search for a config.yaml")
+	flag.Parse()
 }
 
 func main() {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- Please check that here is no existing issue or PR that addresses your problem.

-->
#### Pull Request (PR) description
This PR is a fix for the go flags. Now the API is able to start with a specific config path. I've also fixed the air setup to start the API with it. Also I extended the readme with some more information about how to use air and the config file

#### This Pull Request (PR) fixes the following issues
-